### PR TITLE
fixed the error : AttributeError: 'S3' object has no attribute 'noop'

### DIFF
--- a/whisperbackup/s3.py
+++ b/whisperbackup/s3.py
@@ -30,6 +30,7 @@ class S3(object):
            optional region."""
         self.conn = boto.connect_s3()
         self.bucket = bucket
+        self.noop = noop
 
         b = self.conn.lookup(self.bucket)
         if not noop and b is None:


### PR DESCRIPTION
Today I tried this project to backup our whisper files to S3, but failed. So debug the code, then found there is a neglected define the noop before use it at the 59 line.