### PR TITLE
Respect region upon bucket  creation

### DIFF
--- a/whisperbackup/s3.py
+++ b/whisperbackup/s3.py
@@ -35,7 +35,7 @@ class S3(object):
         b = self.conn.lookup(self.bucket)
         if not noop and b is None:
             # Create the bucket if it doesn't exist
-            self.conn.create_bucket(self.bucket)
+            self.conn.create_bucket(self.bucket, location=region)
 
         self.__b = self.conn.get_bucket(self.bucket)
 


### PR DESCRIPTION
S3 API is not very sane. In order to create a bucket in the desired region, `location` must be given (although already defined upon connection...)

Related: https://github.com/jjneely/whisper-backup/pull/5