### PR TITLE
Optional endpoint argument support

### DIFF
--- a/whisperbackup/whisperbackup.py
+++ b/whisperbackup/whisperbackup.py
@@ -83,7 +83,7 @@ def storageBackend(script):
             region = script.args[2]
         else:
             region = "us-east-1"
-        return s3.S3(script.options.bucket, region, script.options.noop)
+        return s3.S3(script.options.bucket, region, script.options.endpoint, script.options.noop)
     if script.args[1].lower() == "swift":
         import swift
         return swift.Swift(script.options.bucket, script.options.noop)
@@ -463,6 +463,8 @@ def main():
     options.append(make_option("-p", "--prefix", type="string",
         default="/opt/graphite/storage/whisper",
         help="Root of where the whisper files live or will be restored to, default %default"))
+    options.append(make_option("-e", "--endpoint", type="string",
+        help="Optional Endpoint url for cloud backups. If you're using AWS S3 ignore this argument and use region, default %default"))
     options.append(make_option("-f", "--processes", type="int",
         default=4,
         help="Number of worker processes to spawn, default %default"))


### PR DESCRIPTION
optional endpoint argument to support S3 compatible backups. For AWS S3 endpoint parameter is not needed, use the regions(look at docs) for details since boto can do mapping between region and endpoint for AWS S3