### PR TITLE
append backslash to storage path if user omitted it as it fails to upload on correct path for s3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *~
 *.pyc
 *.pyo
+build/
+whisper_backup.egg-info/
 test/

--- a/whisperbackup/pycronscript.py
+++ b/whisperbackup/pycronscript.py
@@ -147,6 +147,9 @@ class CronScript(object):
         self.logger.debug(self.options)
 
     def __enter__(self):
+        if self.options.storage_path > 0 and not self.options.storage_path.endswith('/'):
+            self.options.storage_path = self.options.storage_path + '/'
+
         if self.options.splay > 0:
             splay = randint(0, self.options.splay)
             self.logger.debug('Sleeping for %d seconds (splay=%d)' %


### PR DESCRIPTION
Used case was only tested with s3. The issue I faced was whenever I passed `--storage-path` without adding a `/` at the end of the path, files were upload on s3 but not under the storage directly.

you can replicate it by passing without adding `/`.  `--storage-path $path`.